### PR TITLE
C4v E irrep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 data*
 deprecated
 Manifest.toml
+tmp.jl

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 KrylovKit = "0.9.2"
 Revise = "3.7.3"
 TensorKit = "0.14.3, 0.15"
-julia = "1"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/C3v.jl
+++ b/src/C3v.jl
@@ -25,3 +25,5 @@ const C3v_A2_reps = Dict{Symbol, Int}(
 group_elements(::C3v) = C3v_ops
 irrep_chars(::C3v, ::Val{:A1}) = C3v_A1_reps
 irrep_chars(::C3v, ::Val{:A2}) = C3v_A2_reps
+irrep_rep(::C3v, ::Val{:A1}) = Dict(name => [χ;;] for (name, χ) in C3v_A1_reps)
+irrep_rep(::C3v, ::Val{:A2}) = Dict(name => [χ;;] for (name, χ) in C3v_A2_reps)

--- a/src/C4.jl
+++ b/src/C4.jl
@@ -18,3 +18,5 @@ const C4_B_reps = Dict{Symbol, Int}(
 group_elements(::C4) = C4_ops
 irrep_chars(::C4, ::Val{:A}) = C4_A_reps
 irrep_chars(::C4, ::Val{:B}) = C4_B_reps
+irrep_rep(::C4, ::Val{:A}) = Dict(name => [χ;;] for (name, χ) in C4_A_reps)
+irrep_rep(::C4, ::Val{:B}) = Dict(name => [χ;;] for (name, χ) in C4_B_reps)

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -81,36 +81,14 @@ Returns a pair `(P_sol_a, P_sol_b)` with `P_sol_b = R1 * P_sol_a`.
 function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table::MappingTable=mapping_table(T))
 
     mt = _mapping_table
-
-    f_R = linear_function_for_spatial_operation(C4v_ops[:R1])
-    mat_R = matrix_for_linear_function(T, f_R; _mapping_table=mt)
-
-    rep_R = irrep_rep(C4v(), :E)[:R1]
-    Λ, Q = eigen( Hermitian(-im * rep_R) )
-
-    @show Λ
-    P_1 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[1], _mapping_table=mt)
-    P_2 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[2], _mapping_table=mt)
-
-    if size(P_1, 2) != size(P_2, 2)
-        throw(ArgumentError("split_multiplets expects equal multiplicities for ± eigen-subspaces, got $(size(P_1, 2)) and $(size(P_2, 2))"))
-    end
-
-    P_sol_a = Matrix(qr(P_1 * Q[1, 1] + P_2 * Q[2, 1]).Q)
-
+    
     f_σv1 = linear_function_for_spatial_operation(C4v_ops[:σv1])
-    mat_σv1 = matrix_for_linear_function(T, f_σv1; _mapping_table=mt)
+    rep_σv1 = irrep_rep(C4v(), :E)[:σv1] # rep_σv1 is diagonal
+    P_1 = find_subspace(T, P_sol, (x -> f_σv1(x)); λ= real(rep_σv1[1,1]), _mapping_table=mt)
 
-    rep_σv1 = irrep_rep(C4v(), :E)[:σv1]
-    Λ, Q = eigen( Hermitian(rep_σv1) )
-    @show Λ
-    P_1 = find_subspace(T, P_sol_a, (x -> f_σv1(x)); λ= Λ[1], _mapping_table=mt)
-    P_2 = find_subspace(T, P_sol_a, (x -> f_σv1(x)); λ= Λ[2], _mapping_table=mt)
+    f_σd1 = linear_function_for_spatial_operation(C4v_ops[:σd1])
+    mat_σd1 = matrix_for_linear_function(T, f_σd1; _mapping_table=mt)
+    P_2 = mat_σd1 * P_1
 
-    @show size(P_sol_a)
-    @show size(P_1), size(P_2)
-
-    P_sol_b = mat_R * P_sol_a
-
-    return P_sol_a, P_sol_b
+    return P_1, P_2
 end

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -40,10 +40,33 @@ const C4v_B2_reps = Dict{Symbol, Int}(
     :R1 => -1, :R3 => -1,
     :C2 => 1,
 )
+const C4v_E_reps = Dict{Symbol, Int}(
+    :Id => 2,
+    :σd1 => 0, :σd2 => 0,
+    :σv1 => 0, :σv2 => 0,
+    :R1 => 0, :R3 => 0,
+    :C2 => -2,
+)
+const C4v_E_rep = Dict{Symbol, Matrix{ComplexF64}}(
+    :Id => ComplexF64[1 0; 0 1],
+    :R1 => ComplexF64[0 -1; 1 0],
+    :R3 => ComplexF64[0 1; -1 0],
+    :C2 => ComplexF64[-1 0; 0 -1],
+    :σv1 => ComplexF64[1 0; 0 -1],
+    :σv2 => ComplexF64[-1 0; 0 1],
+    :σd1 => ComplexF64[0 1; 1 0],
+    :σd2 => ComplexF64[0 -1; -1 0],
+)
 
 group_elements(::C4v) = C4v_ops
 irrep_chars(::C4v, ::Val{:A1}) = C4v_A1_reps
 irrep_chars(::C4v, ::Val{:A2}) = C4v_A2_reps
 irrep_chars(::C4v, ::Val{:B1}) = C4v_B1_reps
 irrep_chars(::C4v, ::Val{:B2}) = C4v_B2_reps
+irrep_chars(::C4v, ::Val{:E}) = Dict(name => tr(mat) for (name, mat) in C4v_E_rep)
 
+irrep_rep(::C4v, ::Val{:A1}) = C4v_A1_reps
+irrep_rep(::C4v, ::Val{:A2}) = C4v_A2_reps
+irrep_rep(::C4v, ::Val{:B1}) = C4v_B1_reps
+irrep_rep(::C4v, ::Val{:B2}) = C4v_B2_reps
+irrep_rep(::C4v, ::Val{:E}) = C4v_E_rep

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -65,8 +65,8 @@ irrep_chars(::C4v, ::Val{:B1}) = C4v_B1_reps
 irrep_chars(::C4v, ::Val{:B2}) = C4v_B2_reps
 irrep_chars(::C4v, ::Val{:E}) = Dict(name => tr(mat) for (name, mat) in C4v_E_rep)
 
-irrep_rep(::C4v, ::Val{:A1}) = C4v_A1_reps
-irrep_rep(::C4v, ::Val{:A2}) = C4v_A2_reps
-irrep_rep(::C4v, ::Val{:B1}) = C4v_B1_reps
-irrep_rep(::C4v, ::Val{:B2}) = C4v_B2_reps
+irrep_rep(::C4v, ::Val{:A1}) = Dict(name => [χ;;] for (name, χ) in C4v_A1_reps)
+irrep_rep(::C4v, ::Val{:A2}) = Dict(name => [χ;;] for (name, χ) in C4v_A2_reps)
+irrep_rep(::C4v, ::Val{:B1}) = Dict(name => [χ;;] for (name, χ) in C4v_B1_reps)
+irrep_rep(::C4v, ::Val{:B2}) = Dict(name => [χ;;] for (name, χ) in C4v_B2_reps)
 irrep_rep(::C4v, ::Val{:E}) = C4v_E_rep

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -71,6 +71,13 @@ irrep_rep(::C4v, ::Val{:B1}) = Dict(name => [χ;;] for (name, χ) in C4v_B1_reps
 irrep_rep(::C4v, ::Val{:B2}) = Dict(name => [χ;;] for (name, χ) in C4v_B2_reps)
 irrep_rep(::C4v, ::Val{:E}) = C4v_E_rep
 
+"""
+    split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table=mapping_table(T))
+
+Split the E-irrep subspace `P_sol` into two multiplet components using the
+eigenspaces of `-im * R1` and the C4v E-representation basis.
+Returns a pair `(P_sol_a, P_sol_b)` with `P_sol_b = R1 * P_sol_a`.
+"""
 function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table::MappingTable=mapping_table(T))
 
     mt = _mapping_table
@@ -91,5 +98,4 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
     P_sol_b = mat_R * P_sol_a
 
     return P_sol_a, P_sol_b
-
 end

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -88,6 +88,7 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
     rep_R = irrep_rep(C4v(), :E)[:R1]
     Λ, Q = eigen( Hermitian(-im * rep_R) )
 
+    @show Λ
     P_1 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[1], _mapping_table=mt)
     P_2 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[2], _mapping_table=mt)
 
@@ -96,6 +97,18 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
     end
 
     P_sol_a = Matrix(qr(P_1 * Q[1, 1] + P_2 * Q[2, 1]).Q)
+
+    f_σv1 = linear_function_for_spatial_operation(C4v_ops[:σv1])
+    mat_σv1 = matrix_for_linear_function(T, f_σv1; _mapping_table=mt)
+
+    rep_σv1 = irrep_rep(C4v(), :E)[:σv1]
+    Λ, Q = eigen( Hermitian(rep_σv1) )
+    @show Λ
+    P_1 = find_subspace(T, P_sol_a, (x -> f_σv1(x)); λ= Λ[1], _mapping_table=mt)
+    P_2 = find_subspace(T, P_sol_a, (x -> f_σv1(x)); λ= Λ[2], _mapping_table=mt)
+
+    @show size(P_sol_a)
+    @show size(P_1), size(P_2)
 
     P_sol_b = mat_R * P_sol_a
 

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -70,3 +70,21 @@ irrep_rep(::C4v, ::Val{:A2}) = Dict(name => [χ;;] for (name, χ) in C4v_A2_reps
 irrep_rep(::C4v, ::Val{:B1}) = Dict(name => [χ;;] for (name, χ) in C4v_B1_reps)
 irrep_rep(::C4v, ::Val{:B2}) = Dict(name => [χ;;] for (name, χ) in C4v_B2_reps)
 irrep_rep(::C4v, ::Val{:E}) = C4v_E_rep
+
+function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table::MappingTable=mapping_table(T))
+
+    mt = _mapping_table
+
+    f_R = linear_function_for_spatial_operation(C4v_ops[:R1])
+    rep_R = irrep_rep(C4v(), :E)[:R1]
+    Λ, Q = eigen( Hermitian(-im * rep_R) )
+
+    P_1 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[1], _mapping_table=mt)
+    P_2 = find_subspace(T, P_sol, (x -> -im * f_R(x)); λ= Λ[2], _mapping_table=mt)
+
+    P_sol_a = P_1 * Q[1, 1] + P_2 * Q[2, 1]
+    P_sol_b = P_1 * Q[1, 2] + P_2 * Q[2, 2]
+   
+    return P_sol_a, P_sol_b
+
+end

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -86,7 +86,7 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
 
     f_σd1 = linear_function_for_spatial_operation(C4v_ops[:σd1])
     mat_σd1 = matrix_for_linear_function(T, f_σd1; _mapping_table=mt)
-    P_2 = mat_σd1 * P_1
+    P_2 = mat_σd1 * P_1 # fix the basis of P_2 to be consistent with P_1
 
     return P_1, P_2
 end

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -74,9 +74,7 @@ irrep_rep(::C4v, ::Val{:E}) = C4v_E_rep
 """
     split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table=mapping_table(T))
 
-Split the E-irrep subspace `P_sol` into two multiplet components using the
-eigenspaces of `-im * R1` and the C4v E-representation basis.
-Returns a pair `(P_sol_a, P_sol_b)` with `P_sol_b = R1 * P_sol_a`.
+    Split the E-irrep subspace `P_sol` into two multiplet components.
 """
 function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{<:Number}; _mapping_table::MappingTable=mapping_table(T))
 

--- a/src/C4v.jl
+++ b/src/C4v.jl
@@ -84,6 +84,7 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
 
     f_R = linear_function_for_spatial_operation(C4v_ops[:R1])
     mat_R = matrix_for_linear_function(T, f_R; _mapping_table=mt)
+
     rep_R = irrep_rep(C4v(), :E)[:R1]
     Λ, Q = eigen( Hermitian(-im * rep_R) )
 
@@ -95,6 +96,7 @@ function split_multiplets(::C4v, T::AbstractTensorMap, ::Val{:E}, P_sol::Matrix{
     end
 
     P_sol_a = Matrix(qr(P_1 * Q[1, 1] + P_2 * Q[2, 1]).Q)
+
     P_sol_b = mat_R * P_sol_a
 
     return P_sol_a, P_sol_b

--- a/src/C6v.jl
+++ b/src/C6v.jl
@@ -47,3 +47,7 @@ irrep_chars(::C6v, ::Val{:A1}) = C6v_A1_reps
 irrep_chars(::C6v, ::Val{:A2}) = C6v_A2_reps
 irrep_chars(::C6v, ::Val{:B1}) = C6v_B1_reps
 irrep_chars(::C6v, ::Val{:B2}) = C6v_B2_reps
+irrep_rep(::C6v, ::Val{:A1}) = Dict(name => [χ;;] for (name, χ) in C6v_A1_reps)
+irrep_rep(::C6v, ::Val{:A2}) = Dict(name => [χ;;] for (name, χ) in C6v_A2_reps)
+irrep_rep(::C6v, ::Val{:B1}) = Dict(name => [χ;;] for (name, χ) in C6v_B1_reps)
+irrep_rep(::C6v, ::Val{:B2}) = Dict(name => [χ;;] for (name, χ) in C6v_B2_reps)

--- a/src/D2.jl
+++ b/src/D2.jl
@@ -26,3 +26,7 @@ irrep_chars(::D2, ::Val{:A}) = D2_A_reps
 irrep_chars(::D2, ::Val{:B1}) = D2_B1_reps
 irrep_chars(::D2, ::Val{:B2}) = D2_B2_reps
 irrep_chars(::D2, ::Val{:B3}) = D2_B3_reps
+irrep_rep(::D2, ::Val{:A}) = Dict(name => [χ;;] for (name, χ) in D2_A_reps)
+irrep_rep(::D2, ::Val{:B1}) = Dict(name => [χ;;] for (name, χ) in D2_B1_reps)
+irrep_rep(::D2, ::Val{:B2}) = Dict(name => [χ;;] for (name, χ) in D2_B2_reps)
+irrep_rep(::D2, ::Val{:B3}) = Dict(name => [χ;;] for (name, χ) in D2_B3_reps)

--- a/src/find_subspace.jl
+++ b/src/find_subspace.jl
@@ -63,7 +63,7 @@ end
 Project an initial subspace `P_init` onto the eigenspace of `f_op` with eigenvalue `λ`.
 Returns the basis matrix for the resulting subspace.
 """
-function find_subspace(T::AbstractTensorMap, P_init::Matrix{<:Number}, f_op::Function; λ::Real=1.0, is_hermitian::Bool=false, tol::Real=1e-8, _mapping_table::MappingTable=mapping_table(T))
+function find_subspace(T::AbstractTensorMap, P_init::Matrix{<:Number}, f_op::Function; λ::Number=1.0, is_hermitian::Bool=false, tol::Real=1e-8, _mapping_table::MappingTable=mapping_table(T))
 
     init_subspace_size = size(P_init, 2)
     if init_subspace_size == 0

--- a/src/pointgroup.jl
+++ b/src/pointgroup.jl
@@ -33,6 +33,7 @@ Return a dict of representation matrices for an irrep keyed by element symbols.
 function irrep_rep(::AbstractPointGroup, ::Val{reps_name}) where {reps_name}
     throw(ArgumentError("irrep_rep not implemented for this point group"))
 end
+irrep_rep(spg::AbstractPointGroup, reps_name::Symbol) = irrep_rep(spg, Val(reps_name))
 
 """
     irrep_dim(spg::AbstractPointGroup, ::Val{reps_name})
@@ -43,8 +44,7 @@ function irrep_dim(spg::AbstractPointGroup, ::Val{reps_name}) where {reps_name}
     rep = irrep_rep(spg, reps_name)
     return size(rep[:Id], 1)
 end
-
-irrep_rep(spg::AbstractPointGroup, reps_name::Symbol) = irrep_rep(spg, Val(reps_name))
+irrep_dim(spg::AbstractPointGroup, reps_name::Symbol) = irrep_dim(spg, Val(reps_name))
 
 """
     projector_function(spg::AbstractPointGroup, reps_name::Symbol)

--- a/src/pointgroup.jl
+++ b/src/pointgroup.jl
@@ -26,6 +26,17 @@ end
 irrep_chars(spg::AbstractPointGroup, reps_name::Symbol) = irrep_chars(spg, Val(reps_name))
 
 """
+    irrep_rep(spg::AbstractPointGroup, ::Val{reps_name})
+
+Return a dict of representation matrices for an irrep keyed by element symbols.
+"""
+function irrep_rep(::AbstractPointGroup, ::Val{reps_name}) where {reps_name}
+    throw(ArgumentError("irrep_rep not implemented for this point group"))
+end
+
+irrep_rep(spg::AbstractPointGroup, reps_name::Symbol) = irrep_rep(spg, Val(reps_name))
+
+"""
     projector_function(spg::AbstractPointGroup, reps_name::Symbol)
 
 Return a function that applies the irrep projector: P = d_reps / |G| ∑_{g ∈ G} conj(χ)(g) ρ(g)

--- a/src/pointgroup.jl
+++ b/src/pointgroup.jl
@@ -77,8 +77,6 @@ function projector_function(spg::AbstractPointGroup, reps_name::Symbol)
     end
 end
 
-
-
 """
     find_subspace(spg::AbstractPointGroup, T::AbstractTensorMap, reps_name::Symbol; P_filter=nothing, verbose=false, tol=1e-8)
 
@@ -100,6 +98,14 @@ end
 Return normalized tensor solutions transforming under `reps_name` of `spg`.
 """
 function find_solution(spg::AbstractPointGroup, T::AbstractTensorMap, reps_name::Symbol; P_filter=nothing)
-    P_sol = find_subspace(spg, T, reps_name; P_filter=P_filter)
-    return find_solution(T, P_sol)
+    if irrep_dim(spg, reps_name) == 1
+        P_sol = find_subspace(spg, T, reps_name; P_filter=P_filter)
+        return find_solution(T, P_sol)
+    end
+    
+    if irrep_dim(spg, reps_name) > 1
+        P_sol_mixed = find_subspace(spg, T, reps_name; P_filter=P_filter)
+        P_sol_multiplets = split_multiplets(spg, T, Val(reps_name), P_sol_mixed)
+        return vcat(find_solution.(Ref(T), P_sol_multiplets)...)
+    end
 end

--- a/src/u1_charge_conjugation.jl
+++ b/src/u1_charge_conjugation.jl
@@ -40,6 +40,6 @@ end
 
 Project `P_init` onto the charge-conjugation eigenspace with eigenvalue `λ`.
 """
-function find_subspace_for_u1_charge_conjugation(T::AbstractTensorMap{N, U1GradedSpace}, P_init::Matrix{<:Number}; λ::Real=1.0, _mapping_table::MappingTable=mapping_table(T)) where N
+function find_subspace_for_u1_charge_conjugation(T::AbstractTensorMap{N, U1GradedSpace}, P_init::Matrix{<:Number}; λ::Number=1.0, _mapping_table::MappingTable=mapping_table(T)) where N
     return find_subspace(T, P_init, u1_charge_conjugation; λ=λ, _mapping_table=_mapping_table)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,6 @@ using SpatiallySymmetricTensors
 include("test_spatial_operations.jl");
 include("test_defined_pointgroup.jl");
 include("test_pointgroup.jl");
+include("test_pointgroup_2dirreps.jl");
 include("test_square_lattice_SU2.jl");
 include("test_u1_charge_conjugation.jl");

--- a/test/test_defined_pointgroup.jl
+++ b/test/test_defined_pointgroup.jl
@@ -85,3 +85,21 @@ end
         end
     end
 end
+
+@testset "defined point groups: representations " begin
+
+    group = C4v()
+
+    for irrep in (:A1, :A2, :B1, :B2, :E)
+        rep = SpatiallySymmetricTensors.irrep_rep(group, irrep)
+        Id_mat = rep[:Id]
+        _is_identity(M) = norm(M - Id_mat) < 1e-12
+        @test _is_identity(rep[:R1]^4)
+        @test _is_identity(rep[:R3]^4)
+        @test _is_identity(rep[:C2]^2)
+        @test _is_identity(rep[:σv1]^2)
+        @test _is_identity(rep[:σv2]^2)
+        @test _is_identity(rep[:σd1]^2)
+        @test _is_identity(rep[:σd2]^2)
+    end
+end

--- a/test/test_defined_pointgroup.jl
+++ b/test/test_defined_pointgroup.jl
@@ -87,19 +87,30 @@ end
 end
 
 @testset "defined point groups: representations " begin
+    function is_identity_rep(M, Id_mat)
+        return norm(M - Id_mat) < 1e-12
+    end
 
-    group = C4v()
-
-    for irrep in (:A1, :A2, :B1, :B2, :E)
-        rep = SpatiallySymmetricTensors.irrep_rep(group, irrep)
-        Id_mat = rep[:Id]
-        _is_identity(M) = norm(M - Id_mat) < 1e-12
-        @test _is_identity(rep[:R1]^4)
-        @test _is_identity(rep[:R3]^4)
-        @test _is_identity(rep[:C2]^2)
-        @test _is_identity(rep[:σv1]^2)
-        @test _is_identity(rep[:σv2]^2)
-        @test _is_identity(rep[:σd1]^2)
-        @test _is_identity(rep[:σd2]^2)
+    # reflections / C2 elements square to identity
+    # rotations: order checks
+    for (group, irreps, rotation_order) in [
+        (C4v(), (:A1, :A2, :B1, :B2, :E), 4),
+        (C4(), (:A, :B), 4),
+        (C6v(), (:A1, :A2, :B1, :B2), 6),
+        (C3v(), (:A1, :A2), 3),
+    ]
+        rep_all = SpatiallySymmetricTensors.group_elements(group)
+        for irrep in irreps
+            rep = SpatiallySymmetricTensors.irrep_rep(group, irrep)
+            Id_mat = rep[:Id]
+            for name in keys(rep_all)
+                if occursin("σ", String(name)) || occursin("C2", String(name))
+                    @test is_identity_rep(rep[name]^2, Id_mat)
+                end
+                if occursin("R", String(name))
+                    @test is_identity_rep(rep[name]^rotation_order, Id_mat)
+                end
+            end
+        end
     end
 end

--- a/test/test_pointgroup_2dirreps.jl
+++ b/test/test_pointgroup_2dirreps.jl
@@ -25,6 +25,7 @@ end
         T1, T2 = T_sol[ix], T_sol[ix+nsol]
         for (gname, gperm) in C4v_ops
             rep_g = C4v_E_rep[gname]
+            # [g(T1), g(T2)] =[T1 T2] * rep_g
             @test norm(T1 * rep_g[1, 1] + T2 * rep_g[2, 1] - permute(T1, gperm)) < 1e-10
             @test norm(T1 * rep_g[1, 2] + T2 * rep_g[2, 2] - permute(T2, gperm)) < 1e-10
         end

--- a/test/test_pointgroup_2dirreps.jl
+++ b/test/test_pointgroup_2dirreps.jl
@@ -21,11 +21,11 @@ end
     C4v_ops = SpatiallySymmetricTensors.group_elements(C4v())
     C4v_E_rep = SpatiallySymmetricTensors.irrep_rep(C4v(), :E)
 
-    T1, T2 = T_sol[1], T_sol[nsol+1]
-    for (gname, gperm) in C4v_ops
-        @show gname
-        rep_g = C4v_E_rep[gname]
-        @show norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm))
-        #@test norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm)) < 1e-10
-    end
+    #T1, T2 = T_sol[1], T_sol[nsol+1]
+    #for (gname, gperm) in C4v_ops
+    #    @show gname
+    #    rep_g = C4v_E_rep[gname]
+    #    @show norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm))
+    #    #@test norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm)) < 1e-10
+    #end
 end

--- a/test/test_pointgroup_2dirreps.jl
+++ b/test/test_pointgroup_2dirreps.jl
@@ -1,0 +1,9 @@
+@testset "projector_function C4v E irrep" begin
+    V = SU2Space(1//2=>1, 0=>1)
+    P = SU2Space(1//2=>1)
+    T = rand(ComplexF64, P, V^4)
+
+    fproj = SpatiallySymmetricTensors.projector_function(C4v(), :E)
+    Tp = fproj(T)
+    @test norm(fproj(Tp) - Tp) < 1e-10
+end

--- a/test/test_pointgroup_2dirreps.jl
+++ b/test/test_pointgroup_2dirreps.jl
@@ -21,11 +21,12 @@ end
     C4v_ops = SpatiallySymmetricTensors.group_elements(C4v())
     C4v_E_rep = SpatiallySymmetricTensors.irrep_rep(C4v(), :E)
 
-    #T1, T2 = T_sol[1], T_sol[nsol+1]
-    #for (gname, gperm) in C4v_ops
-    #    @show gname
-    #    rep_g = C4v_E_rep[gname]
-    #    @show norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm))
-    #    #@test norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm)) < 1e-10
-    #end
+    for ix in 1:nsol
+        T1, T2 = T_sol[ix], T_sol[ix+nsol]
+        for (gname, gperm) in C4v_ops
+            rep_g = C4v_E_rep[gname]
+            @test norm(T1 * rep_g[1, 1] + T2 * rep_g[2, 1] - permute(T1, gperm)) < 1e-10
+            @test norm(T1 * rep_g[1, 2] + T2 * rep_g[2, 2] - permute(T2, gperm)) < 1e-10
+        end
+    end
 end

--- a/test/test_pointgroup_2dirreps.jl
+++ b/test/test_pointgroup_2dirreps.jl
@@ -7,3 +7,25 @@
     Tp = fproj(T)
     @test norm(fproj(Tp) - Tp) < 1e-10
 end
+
+@testset "find_solution C4v E irrep" begin
+
+    V = SU2Space(1//2=>1, 0=>1)
+    P = SU2Space(1//2=>1)
+    T = rand(ComplexF64, P, V^4)
+
+    T_sol = find_solution(C4v(), T, :E)
+    @test length(T_sol) % 2 == 0
+    nsol = length(T_sol) ÷ 2
+
+    C4v_ops = SpatiallySymmetricTensors.group_elements(C4v())
+    C4v_E_rep = SpatiallySymmetricTensors.irrep_rep(C4v(), :E)
+
+    T1, T2 = T_sol[1], T_sol[nsol+1]
+    for (gname, gperm) in C4v_ops
+        @show gname
+        rep_g = C4v_E_rep[gname]
+        @show norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm))
+        #@test norm(rep_g[1, 1] * T1 + rep_g[2, 1] * T2 - permute(T1, gperm)) < 1e-10
+    end
+end


### PR DESCRIPTION

- Added/expanded point-group support and representations, namely `:E` irrep for `C4v` group

other minor changes:
- Widened `λ` to `Number` in `find_subspace`/`find_subspace_for_u1_charge_conjugation` for complex eigenvalue selection.
- Minor housekeeping in `.gitignore` and `Project.toml`.